### PR TITLE
Add `build()` function to construct runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +196,7 @@ dependencies = [
 name = "oxide-tokio-rt"
 version = "0.1.1"
 dependencies = [
+ "anyhow",
  "tokio",
  "tokio-dtrace",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ workspace = true
 default = ["rt-multi-thread"]
 rt-multi-thread = ["tokio/rt-multi-thread"]
 
+[dependencies]
+anyhow = "1"
+
 [dependencies.tokio]
 version = "1.45.1"
 features = ["rt"]


### PR DESCRIPTION
This is intended for uses where explicit access to the `Runtime` struct is requried, such as in Propolis.