### PR TITLE
tokio 1.52.0 and related changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,7 +38,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -64,7 +49,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -72,21 +57,6 @@ name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-
-[[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets",
-]
 
 [[package]]
 name = "bitflags"
@@ -238,12 +208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
 name = "goblin"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,9 +238,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "log"
@@ -301,44 +265,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "nix"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -440,12 +386,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
-
-[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,12 +468,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -605,18 +545,17 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -632,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -771,85 +710,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,14 +44,14 @@ version = "0.31"
 features = ["signal"]
 
 [dependencies.tokio]
-version = "1.45.1"
+version = "1.52.0"
 features = ["rt"]
 
 [target.'cfg(target_os = "illumos")'.dependencies.tokio-dtrace]
 version = "0.1.0"
 
 [dev-dependencies.tokio]
-version = "1.45.1"
+version = "1.52.0"
 features = ["rt", "macros", "io-util", "net"]
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ In particular, it currently does the following:
 
 - On illumos, configures the runtime to emit DTrace probes, using 
   [`tokio-dtrace`].
+- Enables [eager I/O and time driver handoff][eager] for the [multi-threaded
+  Tokio runtime][rt-mt].
+
+  This is currently an experimental feature, although it is your author's
+  opinion that this is really a fix for incorrect runtime behavior. It changes
+  worker threads in the multi-threaded runtime to wake another worker prior to
+  polling tasks if that worker had previously been parked on the I/O driver or
+  timer wheel. Eagerly handing off these resources prevents pathologies such
+  as [omicron#9619].
 - Provides [other process initialization utilities](#other-utilities) for
   software using Tokio.
   
@@ -229,8 +238,9 @@ fn main() {
 [Tokio]: https://tokio.rs
 [runtime]: https://docs.rs/tokio/latest/tokio/runtime/index.html
 [`#\[tokio::main\]`]: https://docs.rs/tokio/latest/tokio/attr.main.html
+[eager]: https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.enable_eager_driver_handoff
 [`tokio-dtrace`]: https://github.com/oxidecomputer/tokio-dtrace
-[omicron#8334]: https://github.com/oxidecomputer/omicron/issues/8334#issuecomment-2993159283
+[omicron#9619]: https://github.com/oxidecomputer/omicron/issues/9619
 [unstable features]: https://docs.rs/tokio/latest/tokio/#unstable-features
 [rt-mt]: https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.new_multi_thread
 [`tokio::runtime::Builder`]: https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html

--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ In particular, it currently does the following:
 
 - On illumos, configures the runtime to emit DTrace probes, using 
   [`tokio-dtrace`].
-- Disables Tokio's [LIFO slot optimization]. This feature is intended to 
-  improve message-passing latency, but because tasks in the LIFO slot do not
-  currently participate in work-stealing, it can result in extreme latency spikes in some cases (see [omicron#8334] for a worked example).
 - Provides [other process initialization utilities](#other-utilities) for
   software using Tokio.
   
@@ -233,7 +230,6 @@ fn main() {
 [runtime]: https://docs.rs/tokio/latest/tokio/runtime/index.html
 [`#\[tokio::main\]`]: https://docs.rs/tokio/latest/tokio/attr.main.html
 [`tokio-dtrace`]: https://github.com/oxidecomputer/tokio-dtrace
-[LIFO slot optimization]: https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.disable_lifo_slot
 [omicron#8334]: https://github.com/oxidecomputer/omicron/issues/8334#issuecomment-2993159283
 [unstable features]: https://docs.rs/tokio/latest/tokio/#unstable-features
 [rt-mt]: https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.new_multi_thread

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,6 @@ compile_error!(
 /// following configuration options set on the [`tokio::runtime::Builder`] are
 /// *always* overridden by `oxide-tokio-rt`:
 ///
-/// - [`tokio::runtime::Builder::disable_lifo_slot`]
 /// - [`tokio::runtime::Builder::on_task_spawn`]
 /// - [`tokio::runtime::Builder::on_before_task_poll`]
 /// - [`tokio::runtime::Builder::on_after_task_poll`]
@@ -319,19 +318,6 @@ impl<'a> OxideBuilder<'a> {
                 anyhow::anyhow!("failed to initialize tokio-dtrace probes: {e}")
             },
         )?;
-
-        // Tokio's "LIFO slot optimization" will place the last task notified by
-        // another task on a worker thread in a special slot that is polled
-        // before any other tasks from that worker's run queue. This is intended
-        // to reduce latency in message-passing systems. However, the LIFO slot
-        // currently does not participate in work-stealing, meaning that it can
-        // actually *increase* latency substantially when the task that caused
-        // the wakeup goes CPU-bound for a long period of time. Therefore, we
-        // disable this optimization until the LIFO slot is made stealable.
-        //
-        // See: https://github.com/tokio-rs/tokio/issues/4941
-        #[cfg(tokio_unstable)]
-        self.tokio_builder.as_mut().disable_lifo_slot();
 
         self.tokio_builder.as_mut().enable_all().build().map_err(|e| {
             anyhow::anyhow!("failed to initialize Tokio runtime: {e}")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,6 +312,15 @@ impl<'a> OxideBuilder<'a> {
                 })?;
         }
 
+        // Enable eager I/O and time driver hand-off (see tokio-rs/tokio#8010).
+        // This should prevent pathologies such as omicron#9619.
+        //
+        // Since this builder option requires the `tokio/rt-multi-thread`
+        // feature, we only enable it when *our* corresponding feature flag is
+        // enabled.
+        #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
+        self.tokio_builder.as_mut().enable_eager_driver_handoff();
+
         #[cfg(target_os = "illumos")]
         tokio_dtrace::register_hooks(self.tokio_builder.as_mut()).map_err(
             |e| {


### PR DESCRIPTION
This updates our minimum Tokio version to [1.52.0]. This allows us to
pick up two major fixes that will change our default runtime
configuration:

- https://github.com/tokio-rs/tokio/pull/8010 (released in [1.52.0]) which fixes
  https://github.com/oxidecomputer/omicron/issues/9619 when its builder option is enabled,
- https://github.com/tokio-rs/tokio/pull/7431,(released in [1.51.0]), which allows tasks in the
  LIFO slot to participate in work-stealing.

[1.52.0]: https://github.com/tokio-rs/tokio/releases/tag/tokio-1.52.0
[1.51.0]: https://github.com/tokio-rs/tokio/releases/tag/tokio-1.51.0
