### PR TITLE
fix: re-enable disabling the LIFO slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ In particular, it currently does the following:
   polling tasks if that worker had previously been parked on the I/O driver or
   timer wheel. Eagerly handing off these resources prevents pathologies such
   as [omicron#9619].
+- Disables Tokio's [LIFO slot optimization]. This feature is intended to 
+  improve message-passing latency, but because tasks in the LIFO slot do not
+  currently participate in work-stealing, it can result in extreme latency spikes in some cases (see [omicron#8334] for a worked example).
 - Provides [other process initialization utilities](#other-utilities) for
   software using Tokio.
   
@@ -239,6 +242,8 @@ fn main() {
 [`#\[tokio::main\]`]: https://docs.rs/tokio/latest/tokio/attr.main.html
 [eager]: https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.enable_eager_driver_handoff
 [`tokio-dtrace`]: https://github.com/oxidecomputer/tokio-dtrace
+[LIFO slot optimization]: https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.disable_lifo_slot
+[omicron#8334]: https://github.com/oxidecomputer/omicron/issues/8334#issuecomment-2993159283
 [omicron#9619]: https://github.com/oxidecomputer/omicron/issues/9619
 [unstable features]: https://docs.rs/tokio/latest/tokio/#unstable-features
 [rt-mt]: https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.new_multi_thread

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ compile_error!(
 /// following configuration options set on the [`tokio::runtime::Builder`] are
 /// *always* overridden by `oxide-tokio-rt`:
 ///
+/// - [`tokio::runtime::Builder::disable_lifo_slot`]
 /// - [`tokio::runtime::Builder::on_task_spawn`]
 /// - [`tokio::runtime::Builder::on_before_task_poll`]
 /// - [`tokio::runtime::Builder::on_after_task_poll`]
@@ -327,6 +328,19 @@ impl<'a> OxideBuilder<'a> {
                 anyhow::anyhow!("failed to initialize tokio-dtrace probes: {e}")
             },
         )?;
+
+        // Tokio's "LIFO slot optimization" will place the last task notified by
+        // another task on a worker thread in a special slot that is polled
+        // before any other tasks from that worker's run queue. This is intended
+        // to reduce latency in message-passing systems. However, the LIFO slot
+        // currently does not participate in work-stealing, meaning that it can
+        // actually *increase* latency substantially when the task that caused
+        // the wakeup goes CPU-bound for a long period of time. Therefore, we
+        // disable this optimization until the LIFO slot is made stealable.
+        //
+        // See: https://github.com/tokio-rs/tokio/issues/4941
+        #[cfg(tokio_unstable)]
+        self.tokio_builder.as_mut().disable_lifo_slot();
 
         self.tokio_builder.as_mut().enable_all().build().map_err(|e| {
             anyhow::anyhow!("failed to initialize Tokio runtime: {e}")


### PR DESCRIPTION
This reverts commit 66c189b5a5166d7e329f3ec9bbf1ef034e23d9d1, which removed the code for disabling Tokio's LIFO slot optimization. 

We re-enabled the LIFO slot since tokio-rs/tokio#7431 allowed it to participate in work-stealing, and this change was released in Tokio v1.51.0. However, Tokio v1.52.2 contained commit tokio-rs/tokio#8100, which reverted tokio-rs/tokio#7431, due to a performance regression in some applications (tokio-rs/tokio#8065). Therefore, this means that if we update to Tokio v1.52.2, we will once again be susceptible to LIFO-slot-related deadlocks. This commit re-disables the LIFO slot.

Hopefully, we will be able to figure out a solution upstream that allows stealing LIFO tasks while reducing spurious cross-thread wakeups. But for now, I think that we are best off leaving this disabled. Sigh.