### PR TITLE
Remove compilation error when building docs without --cfg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use std::future::Future;
 
 pub use tokio::runtime::Builder;
 
-#[cfg(not(tokio_unstable))]
+#[cfg(all(not(doc), not(tokio_unstable)))]
 compile_error!(
     "`--cfg tokio_unstable` is required to build oxide-tokio-rt.\n\n\
      If your project already sets it in its .cargo/config.toml, make sure\n\


### PR DESCRIPTION
Requested by @ahrens in https://github.com/oxidecomputer/oxide-tokio-rt/pull/5#issuecomment-4410998110!